### PR TITLE
fix: Add UTF-8 encoding to test file loader

### DIFF
--- a/tests/test_code_review_workflow.py
+++ b/tests/test_code_review_workflow.py
@@ -27,7 +27,7 @@ class CodeReviewValidator:
     def load_json(self, filename: str) -> Dict:
         """Load JSON file"""
         filepath = self.artifacts_dir / filename
-        with open(filepath, 'r') as f:
+        with open(filepath, 'r', encoding='utf-8') as f:
             return json.load(f)
     
     def validate_file_structure(self, data: Dict, priority: str) -> List[str]:


### PR DESCRIPTION
## Problem

Tests were failing on Windows with UnicodeDecodeError because JSON files contain Unicode characters (smart quotes, etc.) that can't be decoded with Windows' default cp1252 encoding.

## Solution

Added ncoding='utf-8' parameter to open() call in load_json() method.

## Impact

- Fixes 13 failing tests
- No functional changes to test logic
- Cross-platform compatibility improved

## Testing
python.exe -m pytest test_code_review_workflow.py -v
Expected: All tests pass